### PR TITLE
Add interactive WASD control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .zig-cache/
 zig-out/
 *.o
+zig-x86_64-linux-0.14.1/
+zig-x86_64-linux-0.14.1.tar.xz


### PR DESCRIPTION
## Summary
- implement a simple terminal renderer that draws `@`
- move the character using WASD input
- add tests for movement and rendering
- ignore embedded `zig` toolchain files

## Testing
- `./zig-x86_64-linux-0.14.1/zig build test --summary all`

------
https://chatgpt.com/codex/tasks/task_e_684de9447cc4832c95560ab70e7ae756